### PR TITLE
Deployer logging

### DIFF
--- a/control.lua
+++ b/control.lua
@@ -1,4 +1,5 @@
 require "util"
+require "lualib.logging"
 require "lualib.common"
 require "lualib.deployer"
 require "lualib.scanner"

--- a/locale/en/recursive-blueprints.cfg
+++ b/locale/en/recursive-blueprints.cfg
@@ -11,9 +11,11 @@ recursive-blueprints-scanner=Counts the resources in an area.
 
 [mod-setting-name]
 recursive-blueprints-area=Area X,Y position
+recursive-blueprints-logging=Deployer logging
 
 [mod-setting-description]
 recursive-blueprints-area=Position of the X and Y signals in the deconstruction or upgrade area.
+recursive-blueprints-logging=Condition for displaying debug messages.
 
 [string-mod-setting]
 recursive-blueprints-area-center=Center

--- a/lualib/logging.lua
+++ b/lualib/logging.lua
@@ -38,13 +38,13 @@ function deployer_logging(msg_type, network, vars)
 
   --"point_deploy" "area_deploy" "self_deconstract" "destroy_book" "copy_book"
   if msg_type == "point_deploy" then
-    local target_gps  = " " .. make_gps_string(vars.position, network.deployer.surface)
+    local target_gps  = make_gps_string(vars.position, network.deployer.surface)
     if deployer_gps == target_gps then target_gps = "" end
     msg = "Deployer " .. deployer_gps ..
-          " place bp: " .. make_bp_name_string(vars.bp) .. target_gps
+          " place bp: " .. make_bp_name_string(vars.bp) .. " " ..  target_gps
 
   elseif msg_type == "area_deploy" then
-    local target_gps  = " " .. make_gps_string(get_target_position(network), network.deployer.surface)
+    local target_gps  = make_gps_string(get_target_position(network), network.deployer.surface)
     if deployer_gps == target_gps then target_gps = "" end
     local sub_msg = ""
     if vars.sub_type == "deconstract" then
@@ -57,7 +57,7 @@ function deployer_logging(msg_type, network, vars)
     if not vars.apply then sub_msg = " cansel" .. sub_msg end
     msg = "Deployer " .. deployer_gps ..
           sub_msg .. make_bp_name_string(vars.bp) ..
-          target_gps .. make_area_string(network)
+          " " .. target_gps .. make_area_string(network)
 
   else
     msg = "Deployer " .. deployer_gps .. " sent an unknown message: " .. msg_type

--- a/lualib/logging.lua
+++ b/lualib/logging.lua
@@ -1,0 +1,71 @@
+local LOGGING_SIGNAL = {name="signal-L", type="virtual"}
+
+local function make_gps_string(position, surface)
+  if position and surface then
+    return string.format("[gps=%s,%s,%s]", position.x, position.y, surface.name)
+  else
+    return "[lost location]"
+  end
+end
+
+local function make_area_string(network)
+    if not network then return "" end
+    local W, H = get_area_signals(network)
+    return " W=" .. W ..
+           " H=" .. H
+end
+
+local function make_bp_name_string(bp)
+    if not bp or not bp.valid or not bp.label then return "unnamed" end
+    return bp.label
+end
+
+function deployer_logging(msg_type, network, vars)
+  local log_settings = settings.global["recursive-blueprints-logging"].value
+  if log_settings == "never" then
+    return
+  else
+    local L = get_signal(network, LOGGING_SIGNAL)
+    if (log_settings == "with 'L>0' signal" and L < 1)
+       or (log_settings == "with 'L>=0' signal" and L < 0)
+    then
+      return
+    end
+  end
+  
+  local msg = ""
+  local deployer_gps = make_gps_string(network.deployer.position, network.deployer.surface)
+
+  --"point_deploy" "area_deploy" "self_deconstract" "destroy_book" "copy_book"
+  if msg_type == "point_deploy" then
+    local target_gps  = " " .. make_gps_string(vars.position, network.deployer.surface)
+    if deployer_gps == target_gps then target_gps = "" end
+    msg = "Deployer " .. deployer_gps ..
+          " place bp: " .. make_bp_name_string(vars.bp) .. target_gps
+
+  elseif msg_type == "area_deploy" then
+    local target_gps  = " " .. make_gps_string(get_target_position(network), network.deployer.surface)
+    if deployer_gps == target_gps then target_gps = "" end
+    local sub_msg = ""
+    if vars.sub_type == "deconstract" then
+      sub_msg = " deconstracting area: "
+    elseif vars.sub_type == "upgrade" then
+      sub_msg = " upgrading area: "
+    else
+      sub_msg = " somefing: "
+    end
+    if not vars.apply then sub_msg = " cansel" .. sub_msg end
+    msg = "Deployer " .. deployer_gps ..
+          sub_msg .. make_bp_name_string(vars.bp) ..
+          target_gps .. make_area_string(network)
+
+  else
+    msg = "Deployer " .. deployer_gps .. " sent an unknown message: " .. msg_type
+  end
+
+  if network.deployer.force and network.deployer.force.valid then
+    network.deployer.force.print(msg)
+  else
+    game.print(msg)
+  end
+end

--- a/settings.lua
+++ b/settings.lua
@@ -6,4 +6,11 @@ data:extend{
     default_value = "center",
     allowed_values = {"center", "corner"},
   },
+  {
+    type = "string-setting",
+    name = "recursive-blueprints-logging",
+    setting_type = "runtime-global",
+    default_value = "never",
+    allowed_values = {"never", "with 'L>0' signal", "with 'L>=0' signal", "always"},
+  }
 }


### PR DESCRIPTION
This feature was requested by UpsideDownFox.
Displays in the chat the location of the triggered deployer, where and what blueprint was used.
By default, logging is disabled in the settings.

There is room for further development of this feature: "self_deconstract" "destroy_book" "copy_book" messages, errors, ets.